### PR TITLE
Fix default enum value

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PolycubeCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PolycubeCodegen.java
@@ -662,7 +662,7 @@ public class PolycubeCodegen extends DefaultCodegen implements CodegenConfig {
                             p.allowableValues.put("values", l); //add allowable values to enum
 
                         if (p.isEnum && p.defaultValue != null && !p.defaultValue.isEmpty() && !p.defaultValue.contains("\"\"")) {
-                            p.defaultValue = String.format("%s::%s", p.datatype, p.defaultValue);
+                            p.defaultValue = String.format("%s::%s", p.datatype, p.defaultValue.toUpperCase());
                         }
                     }
 


### PR DESCRIPTION
The default value for enums variables was keeping the original case, it cause
compilation problems because enums are transformed to be uppercase.