### PR TITLE
support transparent services

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PolycubeCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PolycubeCodegen.java
@@ -234,7 +234,10 @@ public class PolycubeCodegen extends DefaultCodegen implements CodegenConfig {
             if (codegenModel.vendorExtensions.get("x-parent").equals(codegenModel.name)) {
                 codegenModel.vendorExtensions.remove("x-parent");
                 // TODO: hardcoded value for port class here.
-                codegenModel.vendorExtensions.put("x-inherits-from", "virtual polycube::service::Cube<Ports>");
+                if (codegenModel.vendorExtensions.get("x-is-transparent") != null)
+                    codegenModel.vendorExtensions.put("x-inherits-from", "virtual polycube::service::TransparentCube");
+                else if (codegenModel.vendorExtensions.get("x-is-standard") != null)
+                    codegenModel.vendorExtensions.put("x-inherits-from", "virtual polycube::service::Cube<Ports>");
             }
         }
 
@@ -675,7 +678,8 @@ public class PolycubeCodegen extends DefaultCodegen implements CodegenConfig {
 
                 // TODO: isn't there a smarter way to check if the objet is the root one?
                 if (model.vendorExtensions.containsKey("x-inherits-from") &&
-                    ((String) model.vendorExtensions.get("x-inherits-from")).equals("virtual polycube::service::Cube<Ports>")) {
+                    (((String) model.vendorExtensions.get("x-inherits-from")).equals("virtual polycube::service::Cube<Ports>") ||
+                     ((String) model.vendorExtensions.get("x-inherits-from")).equals("virtual polycube::service::TransparentCube"))) {
                     model.vendorExtensions.put("x-is-root-object", true);
                     rootObjectModel = model;
                 }

--- a/modules/swagger-codegen/src/main/resources/polycube/src/base/Base.cpp.mustache
+++ b/modules/swagger-codegen/src/main/resources/polycube/src/base/Base.cpp.mustache
@@ -31,10 +31,10 @@
 
 void {{classname}}Base::update(const {{classname}}JsonObject &conf) {
 {{#vendorExtensions.x-is-root-object}}
-  Cube::set_conf(conf.getBase());
+  set_conf(conf.getBase());
 {{/vendorExtensions.x-is-root-object}}
 {{#vendorExtensions.x-is-port-class}}
-  Port::set_conf(conf.getBase());
+  set_conf(conf.getBase());
 {{/vendorExtensions.x-is-port-class}}
 
 {{#vars}}
@@ -70,10 +70,10 @@ void {{classname}}Base::update(const {{classname}}JsonObject &conf) {
 {{classname}}JsonObject {{classname}}Base::toJsonObject() {
   {{classname}}JsonObject conf;
 {{#vendorExtensions.x-is-root-object}}
-  conf.setBase(Cube::to_json());
+  conf.setBase(to_json());
 {{/vendorExtensions.x-is-root-object}}
 {{#vendorExtensions.x-is-port-class}}
-  conf.setBase(Port::to_json());
+  conf.setBase(to_json());
 {{/vendorExtensions.x-is-port-class}}
 
 {{#vars}}

--- a/modules/swagger-codegen/src/main/resources/polycube/src/base/Base.h.mustache
+++ b/modules/swagger-codegen/src/main/resources/polycube/src/base/Base.h.mustache
@@ -22,9 +22,15 @@
 #include "../{{{this}}}.h"
 {{/vendorExtensions.x-interface-imports}}
 
-{{#vendorExtensions.x-inherits-from}}
+{{#vendorExtensions.x-is-standard}}
 #include "polycube/services/cube.h"
 #include "polycube/services/port.h"
+{{/vendorExtensions.x-is-standard}}
+{{#vendorExtensions.x-is-transparent}}
+#include "polycube/services/transparent_cube.h"
+{{/vendorExtensions.x-is-transparent}}
+
+{{#vendorExtensions.x-inherits-from}}
 #include "polycube/services/utils.h"
 #include "polycube/services/fifo_map.hpp"
 {{/vendorExtensions.x-inherits-from}}

--- a/modules/swagger-codegen/src/main/resources/polycube/src/object-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/polycube/src/object-header.mustache
@@ -31,12 +31,18 @@ class {{classname}} : public {{classname}}Base {
 {{/vendorExtensions.x-is-port-class}}
 {{/vendorExtensions.x-is-root-object}}
   virtual ~{{classname}}();
-{{#vendorExtensions.x-is-root-object}}
+{{#vendorExtensions.x-is-standard}}
 
   void packet_in({{vendorExtensions.x-child-ports-classname}} &port,
-      polycube::service::PacketInMetadata &md,
-      const std::vector<uint8_t> &packet) override;
-{{/vendorExtensions.x-is-root-object}}
+                 polycube::service::PacketInMetadata &md,
+                 const std::vector<uint8_t> &packet) override;
+{{/vendorExtensions.x-is-standard}}
+{{#vendorExtensions.x-is-transparent}}
+
+  void packet_in(polycube::service::Sense sense,
+                 polycube::service::PacketInMetadata &md,
+                 const std::vector<uint8_t> &packet) override;
+{{/vendorExtensions.x-is-transparent}}
 {{#vars}}
 {{^vendorExtensions.x-has-default-impl}}
 {{^vendorExtensions.x-is-base-datamodel}}

--- a/modules/swagger-codegen/src/main/resources/polycube/src/object-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/polycube/src/object-source.mustache
@@ -11,7 +11,7 @@
 #include "{{classname}}_dp.h"
 
 {{classname}}::{{classname}}({{#vars}}{{#vendorExtensions.x-is-key}}const {{{datatype}}} {{{name}}}, {{/vendorExtensions.x-is-key}}{{/vars}}const {{classname}}JsonObject &conf)
-  : Cube(conf.getBase(), { {{classVarName}}_code }, {}),
+  : {{#vendorExtensions.x-is-transparent}}Transparent{{/vendorExtensions.x-is-transparent}}Cube(conf.getBase(), { {{classVarName}}_code }, {}),
     {{classname}}Base({{#vars}}{{#vendorExtensions.x-is-key}}{{{name}}}{{/vendorExtensions.x-is-key}}{{/vars}}) {
   logger()->info("Creating {{classname}} instance");
 {{#vars}}
@@ -73,13 +73,23 @@
 {{classname}}::~{{classname}}() {
   logger()->info("Destroying {{classname}} instance");
 }
+{{/vendorExtensions.x-parent}}
+{{#vendorExtensions.x-is-standard}}
 
 void {{classname}}::packet_in({{vendorExtensions.x-child-ports-classname}} &port,
     polycube::service::PacketInMetadata &md,
-    const std::vector<uint8_t> &packet){
+    const std::vector<uint8_t> &packet) {
   logger()->debug("Packet received from port {0}", port.name());
 }
-{{/vendorExtensions.x-parent}}
+{{/vendorExtensions.x-is-standard}}
+{{#vendorExtensions.x-is-transparent}}
+
+void {{classname}}::packet_in(polycube::service::Sense sense,
+    polycube::service::PacketInMetadata &md,
+    const std::vector<uint8_t> &packet) {
+    logger()->debug("Packet received");
+}
+{{/vendorExtensions.x-is-transparent}}
 {{#vars}}
 {{^vendorExtensions.x-is-base-datamodel}}
 {{^vendorExtensions.x-has-default-impl}}


### PR DESCRIPTION
The transparent service support was not totally complete, some things were
missing, this commit generates different code for transparent or standard
services based on a vendor extension saved by pyang.

- fixes the signature for packet_in
- fixes base class name (TransparentCube instead of Cube)
- includes the right files

