### PR TITLE
Bug fixes

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -3154,8 +3154,22 @@ public class DefaultCodegen {
             word = m.replaceAll(rep);
         }
 
-        // Remove all underscores
+        // Remove all underscores (underscore_case to camelCase)
         p = Pattern.compile("(_)(.)");
+        m = p.matcher(word);
+        while (m.find()) {
+            String original = m.group(2);
+            String upperCase = original.toUpperCase();
+            if (original.equals(upperCase)) {
+                word = word.replaceFirst("_", "");
+            } else {
+                word = m.replaceFirst(upperCase);
+            }
+            m = p.matcher(word);
+        }
+
+        // Remove all hyphens (hyphen-case to camelCase)
+        p = Pattern.compile("(-)(.)");
         m = p.matcher(word);
         while (m.find()) {
             word = m.replaceFirst(m.group(2).toUpperCase());
@@ -3378,10 +3392,9 @@ public class DefaultCodegen {
 
         // remove everything else other than word, number and _
         // $php_variable => php_variable
-        if (allowUnicodeIdentifiers) { //could be converted to a single line with ?: operator
+        if (allowUnicodeIdentifiers) { // could be converted to a single line with ?: operator
             name = Pattern.compile("\\W", Pattern.UNICODE_CHARACTER_CLASS).matcher(name).replaceAll("");
-        }
-        else {
+        } else {
             name = name.replaceAll("\\W", "");
         }
 
@@ -3395,20 +3408,14 @@ public class DefaultCodegen {
      * @return Sanitized tag
      */
     public String sanitizeTag(String tag) {
-        // remove spaces and make strong case
-        String[] parts = tag.split(" ");
-        StringBuilder buf = new StringBuilder();
-        for (String part : parts) {
-            if (StringUtils.isNotEmpty(part)) {
-                buf.append(StringUtils.capitalize(part));
-            }
+        tag = camelize(sanitizeName(tag));
+
+        // tag starts with numbers
+        if (tag.matches("^\\d.*")) {
+            tag = "Class" + tag;
         }
-        String returnTag = buf.toString().replaceAll("[^a-zA-Z0-9_]", "");
-        if (returnTag.matches("\\d.*")) {
-            return "_" + returnTag;
-        } else {
-            return returnTag;
-        }
+
+        return tag;
     }
 
     /**

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PolycubeCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PolycubeCodegen.java
@@ -873,10 +873,11 @@ public class PolycubeCodegen extends DefaultCodegen implements CodegenConfig {
         objs.put("firstClassnameSnakeLowerCase", DefaultCodegen.underscore(api_classname).toLowerCase());
 
         String service_name = (String) apis.get(0).get("classVarName");
-        service_name = service_name.toLowerCase();
-        objs.put("serviceNameLowerCase", service_name);
+        objs.put("serviceNameLowerCamelCase", service_name);
         String service_name_camel_case = service_name.substring(0, 1).toUpperCase() + service_name.substring(1);
         objs.put("serviceNameCamelCase", service_name_camel_case);
+        service_name = service_name.toLowerCase();
+        objs.put("serviceNameLowerCase", service_name);
 
         if (swagger.getInfo().getVendorExtensions().containsKey("x-yang-path")) {
             String yang_path = (String) swagger.getInfo().getVendorExtensions().get("x-yang-path");

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PolycubeCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PolycubeCodegen.java
@@ -646,12 +646,12 @@ public class PolycubeCodegen extends DefaultCodegen implements CodegenConfig {
                                 }
                                 mv.put("stringValue", lenum.get(j).toLowerCase());//save the string value
                             }
-                            mv.put("value", lenum.get(j).toUpperCase());//save the enum value
+                            mv.put("value", DefaultCodegen.underscore(lenum.get(j)).toUpperCase());//save the enum value
                             l.add(mv);
                             if (j < lenum.size() - 1)
-                                lenum.set(j, lenum.get(j).toUpperCase() + ",");//add comma if the value there are more values
+                                lenum.set(j, DefaultCodegen.underscore(lenum.get(j)).toUpperCase() + ",");//add comma if the value there are more values
                             else
-                                lenum.set(j, lenum.get(j).toUpperCase());
+                                lenum.set(j, DefaultCodegen.underscore(lenum.get(j)).toUpperCase());
                         }
                         if (p.allowableValues != null)
                             p.allowableValues.put("values", l); //add allowable values to enum

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PolycubeCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PolycubeCodegen.java
@@ -832,7 +832,7 @@ public class PolycubeCodegen extends DefaultCodegen implements CodegenConfig {
                 for (CodegenResponse r : op.responses) {
                     if (r.vendorExtensions.get("x-is-enum") != null) {
                         if (r.vendorExtensions.get("x-typedef") != null)
-                            op.returnType = initialCaps((String) r.vendorExtensions.get("x-typedef")) + "Enum";
+                            op.returnType = toUpperCamelCase((String) r.vendorExtensions.get("x-typedef")) + "Enum";
                         else
                             op.returnType = name + initialCaps(var) + "Enum";
                         op.returnBaseType = initialCaps(var);

--- a/modules/swagger-codegen/src/main/resources/polycube/src/CMakeLists.txt.mustache
+++ b/modules/swagger-codegen/src/main/resources/polycube/src/CMakeLists.txt.mustache
@@ -22,7 +22,9 @@ add_library(pcn-{{serviceNameLowerCase}} SHARED
   {{#models}}
   {{#model}}
   {{^vendorExtensions.x-is-yang-action-object}}
+  {{^vendorExtensions.x-is-yang-grouping}}
   {{classname}}.cpp
+  {{/vendorExtensions.x-is-yang-grouping}}
   {{/vendorExtensions.x-is-yang-action-object}}
   {{/model}}
   {{/models}}

--- a/modules/swagger-codegen/src/main/resources/polycube/src/CMakeLists.txt.mustache
+++ b/modules/swagger-codegen/src/main/resources/polycube/src/CMakeLists.txt.mustache
@@ -33,7 +33,7 @@ add_library(pcn-{{serviceNameLowerCase}} SHARED
 # load ebpf datapath code a variable
 load_file_as_variable(pcn-{{serviceNameLowerCase}}
   {{serviceNameCamelCase}}_dp.c
-  {{serviceNameLowerCase}}_code)
+  {{serviceNameLowerCamelCase}}_code)
 
 # load datamodel in a variable
 load_file_as_variable(pcn-{{serviceNameLowerCase}}

--- a/modules/swagger-codegen/src/main/resources/polycube/src/object-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/polycube/src/object-header.mustache
@@ -39,7 +39,7 @@ class {{classname}} : public {{classname}}Base {
 {{/vendorExtensions.x-is-standard}}
 {{#vendorExtensions.x-is-transparent}}
 
-  void packet_in(polycube::service::Sense sense,
+  void packet_in(polycube::service::Direction direction,
                  polycube::service::PacketInMetadata &md,
                  const std::vector<uint8_t> &packet) override;
 {{/vendorExtensions.x-is-transparent}}

--- a/modules/swagger-codegen/src/main/resources/polycube/src/object-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/polycube/src/object-source.mustache
@@ -86,7 +86,7 @@ void {{classname}}::packet_in({{vendorExtensions.x-child-ports-classname}} &port
 {{/vendorExtensions.x-is-standard}}
 {{#vendorExtensions.x-is-transparent}}
 
-void {{classname}}::packet_in(polycube::service::Sense sense,
+void {{classname}}::packet_in(polycube::service::Direction direction,
     polycube::service::PacketInMetadata &md,
     const std::vector<uint8_t> &packet) {
     logger()->debug("Packet received");

--- a/modules/swagger-codegen/src/main/resources/polycube/src/object-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/polycube/src/object-source.mustache
@@ -48,11 +48,7 @@
     {{setter}}(conf.{{getter}}());
 {{/isPrimitiveType}}
 {{^isPrimitiveType}}
-  auto value = conf.{{getter}}();
-{{#vendorExtensions.x-key-list}}
-    {{type}} {{varName}}_ = value.{{getter}}();
-{{/vendorExtensions.x-key-list}}
-  add{{nameInCamelCase}}({{#vendorExtensions.x-key-list}}{{varName}}, {{/vendorExtensions.x-key-list}}conf.{{getter}}());
+  add{{nameInCamelCase}}(conf.{{getter}}());
 {{/isPrimitiveType}}
 {{^vendorExtensions.x-is-required}}
 {{^vendorExtensions.x-has-default-value}}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
@@ -17,11 +17,12 @@ public class CodegenTest {
     public void sanitizeTagTest() {
         final DefaultCodegen codegen = new DefaultCodegen();
         Assert.assertEquals(codegen.sanitizeTag("foo"), "Foo");
+        Assert.assertEquals(codegen.sanitizeTag("$foo!"), "Foo");
         Assert.assertEquals(codegen.sanitizeTag("foo bar"), "FooBar");
-        Assert.assertEquals(codegen.sanitizeTag("foo_bar"), "Foo_bar");
+        Assert.assertEquals(codegen.sanitizeTag("foo_bar"), "FooBar");
         Assert.assertEquals(codegen.sanitizeTag("foo1 bar2"), "Foo1Bar2");
         Assert.assertEquals(codegen.sanitizeTag("foo bar 1"), "FooBar1");
-        Assert.assertEquals(codegen.sanitizeTag("1foo"), "_1foo");
+        Assert.assertEquals(codegen.sanitizeTag("1foo"), "Class1foo");
     }
 
     @Test(description = "test camelize")
@@ -32,10 +33,14 @@ public class CodegenTest {
         Assert.assertEquals(codegen.camelize(".foo"), "Foo");
         Assert.assertEquals(codegen.camelize(".foo.bar"), "FooBar");
         Assert.assertEquals(codegen.camelize("foo$bar"), "Foo$bar");
+        Assert.assertEquals(codegen.camelize("foo_$bar"), "Foo$bar");
+
         Assert.assertEquals(codegen.camelize("foo_bar"), "FooBar");
         Assert.assertEquals(codegen.camelize("foo_bar_baz"), "FooBarBaz");
         Assert.assertEquals(codegen.camelize("foo/bar.baz"), "FooBarBaz");
         Assert.assertEquals(codegen.camelize("/foo/bar/baz.qux/corge"), "FooBarBazQuxCorge");
+        Assert.assertEquals(codegen.camelize("foo-bar"), "FooBar");
+        Assert.assertEquals(codegen.camelize("foo-bar-xyzzy"), "FooBarXyzzy");
     }
 
     @Test(description = "read a file upload param from a 2.0 spec")


### PR DESCRIPTION
This PR fixes several bugs.
1. Rename service::Sense to service::Direction for packet_in method of transparent services, according to commit https://github.com/polycube-network/polycube/commit/e6c734f1d1e03a1c1d91f073c07f4a43b50e7318
(Commit e51541d)
2. When using an enum typedef containing '-' the return type of api methods retained the '-' instead of being converted to CamelCase
(Commit 7af8b1c)
3. In src/CMakeLists.txt the add_library statement referenced cpp files related to YANG groupings that aren't generated
(Commit 7511dbe)
4. When using multiple containers in the same node of the model the constructor of the resulting class contained the repeated line of code 'auto value = conf.get<container_name>();'
(Commit ff426b4)
5. Issue https://github.com/polycube-network/polycube-codegen/issues/11 with service names containing '-'
(Commits 56c4c63 and a589be3)